### PR TITLE
Deploy automatico para o PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,12 @@ python:
   - "3.5"
 install: "pip install flake8"
 script: "flake8 --ignore=F821"
+
+deploy:
+  provider: pypi
+  distributions: "sdist bdist_wheel"
+  user: jtemporal
+  password: $PYPI_PASSWORD
+  on:
+    branch: master
+    repo: jtemporal/caipyra


### PR DESCRIPTION
Adicionado autodeploy para o PyPI.

Eu reparei que o repositório não utiliza *tags* para as versões, então defini que todo *push* para a *master* irá realizar o *deploy* no PyPI.

Para funcionar basta adicionar a variável de ambiente `PYPI_PASSWORD` com o seu senha de usuário do PyPi. https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings

Close https://github.com/jtemporal/caipyra/issues/21